### PR TITLE
Fix neative teleport coords

### DIFF
--- a/DeveloperConsole.UnitTests/CommandParserTests.cs
+++ b/DeveloperConsole.UnitTests/CommandParserTests.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using DeveloperConsole.UnitTests.Fakes;
+
+namespace DeveloperConsole.UnitTests {
+	[TestClass]
+	public class CommandParserTests {
+		
+		[TestMethod]
+		public void cmdParser_HandlesPositiveNumbers() {
+			FakeDeveloperConsole console = new FakeDeveloperConsole();
+			CommandParser parser = new CommandParser("12", console);
+
+			CommandToken token = parser.Next();
+			Assert.AreEqual(CommandTokenKind.Number, token.Kind);
+			Assert.AreEqual("12", token.String);
+		}
+
+		[TestMethod]
+		public void cmdParser_HandlesDecimalNumbers() {
+			FakeDeveloperConsole console = new FakeDeveloperConsole();
+			CommandParser parser = new CommandParser("12.5", console);
+
+			CommandToken token = parser.Next();
+			Assert.AreEqual(CommandTokenKind.Number, token.Kind);
+			Assert.AreEqual("12.5", token.String);
+		}
+
+		[TestMethod]
+		public void cmdParser_HandlesNegativeNumbers() {
+			FakeDeveloperConsole console = new FakeDeveloperConsole();
+			CommandParser parser = new CommandParser("-12", console);
+
+			CommandToken token = parser.Next();
+			Assert.AreEqual(CommandTokenKind.Number, token.Kind);
+			Assert.AreEqual("-12", token.String);
+		}
+
+		[TestMethod]
+		public void cmdParser_HandlesNegativeDecimalNumbers() {
+			FakeDeveloperConsole console = new FakeDeveloperConsole();
+			CommandParser parser = new CommandParser("-12.5", console);
+
+			CommandToken token = parser.Next();
+			Assert.AreEqual(CommandTokenKind.Number, token.Kind);
+			Assert.AreEqual("-12.5", token.String);
+		}
+
+		[TestMethod]
+		public void cmdParser_HandlesSoloNegativeAsWord() {
+			FakeDeveloperConsole console = new FakeDeveloperConsole();
+			CommandParser parser = new CommandParser("-", console);
+
+			CommandToken token = parser.Next();
+			Assert.AreEqual(CommandTokenKind.Word, token.Kind);
+			Assert.AreEqual("-", token.String);
+		}
+
+		[TestMethod]
+		public void cmdParser_HandlesNegativePrefixedWordAsWord() {
+			FakeDeveloperConsole console = new FakeDeveloperConsole();
+			CommandParser parser = new CommandParser("-hello", console);
+
+			CommandToken token = parser.Next();
+			Assert.AreEqual(CommandTokenKind.Word, token.Kind);
+			Assert.AreEqual("-hello", token.String);
+		}
+	}
+}

--- a/DeveloperConsole.UnitTests/DeveloperConsole.UnitTests.csproj
+++ b/DeveloperConsole.UnitTests/DeveloperConsole.UnitTests.csproj
@@ -1,0 +1,90 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4AC3D594-4C40-4E8B-A632-8BC03AE27CBA}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>DeveloperConsole.UnitTests</RootNamespace>
+    <AssemblyName>DeveloperConsole.UnitTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="CommandParserTests.cs" />
+    <Compile Include="Fakes\FakeDeveloperConsole.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\gtav_console\DeveloperConsole.csproj">
+      <Project>{effe7239-0a6b-4dec-bb24-6cb563ec48a7}</Project>
+      <Name>DeveloperConsole</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/DeveloperConsole.UnitTests/Fakes/FakeDeveloperConsole.cs
+++ b/DeveloperConsole.UnitTests/Fakes/FakeDeveloperConsole.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DeveloperConsole.UnitTests.Fakes {
+	public class FakeDeveloperConsole : IDeveloperConsole {
+		public void PrintError(string s) {
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/DeveloperConsole.UnitTests/Properties/AssemblyInfo.cs
+++ b/DeveloperConsole.UnitTests/Properties/AssemblyInfo.cs
@@ -5,25 +5,22 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-
-[assembly: AssemblyTitle("ScriptHookVDotNet Developer Console")]
+[assembly: AssemblyTitle("DeveloperConsole.UnitTests")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DeveloperConsole.Properties")]
-[assembly: AssemblyCopyright("Dakota628")]
+[assembly: AssemblyProduct("DeveloperConsole.UnitTests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
-
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-
-[assembly: Guid("6597bda1-b96b-4c48-a964-bc1f00afc537")]
+[assembly: Guid("dc01ccc0-f105-4578-a38c-4eff5c43331e")]
 
 // Version information for an assembly consists of the following four values:
 //
@@ -32,8 +29,8 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-
-[assembly: AssemblyVersion("9.9.9.9")]
-[assembly: AssemblyFileVersion("9.9.9.9")]
-
-[assembly:InternalsVisibleTo("DeveloperConsole.UnitTests")]
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/DeveloperConsole.sln
+++ b/DeveloperConsole.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeveloperConsole", "gtav_console\DeveloperConsole.csproj", "{EFFE7239-0A6B-4DEC-BB24-6CB563EC48A7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeveloperConsole.UnitTests", "DeveloperConsole.UnitTests\DeveloperConsole.UnitTests.csproj", "{4AC3D594-4C40-4E8B-A632-8BC03AE27CBA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{EFFE7239-0A6B-4DEC-BB24-6CB563EC48A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EFFE7239-0A6B-4DEC-BB24-6CB563EC48A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EFFE7239-0A6B-4DEC-BB24-6CB563EC48A7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4AC3D594-4C40-4E8B-A632-8BC03AE27CBA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4AC3D594-4C40-4E8B-A632-8BC03AE27CBA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4AC3D594-4C40-4E8B-A632-8BC03AE27CBA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4AC3D594-4C40-4E8B-A632-8BC03AE27CBA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/gtav_console/Commands/CommandParser.cs
+++ b/gtav_console/Commands/CommandParser.cs
@@ -2,6 +2,7 @@
 using System.CodeDom.Compiler;
 using GTA;
 using Microsoft.CSharp;
+using System.Linq;
 
 namespace DeveloperConsole {
     internal class CommandParser {
@@ -23,6 +24,7 @@ namespace DeveloperConsole {
         }
 
         public char[] SymbolChars { get; set; }
+		public char[] Didgets { get; set; }
         public bool IgnoreWhiteSpace { get; set; }
 
         private void Reset() {
@@ -32,6 +34,8 @@ namespace DeveloperConsole {
                 ';',
                 '<', '>', '?', '|', '\\'
             };
+
+			Didgets = new[] {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'};
 
             _line = 1;
             _column = 1;
@@ -127,6 +131,14 @@ namespace DeveloperConsole {
                 }
 
                 default: {
+					if(ch == '-') {
+						char following = LA(1);
+						bool isFollowingDidget = Didgets.Any(x => x == following);
+						if(isFollowingDidget) {
+							return ReadNumber();
+						}
+					}
+
                     if (char.IsLetter(ch) || ch == '_' || ch == '-' || ch == '.') return ReadWord();
                     if (IsSymbol(ch)) {
                         StartRead();

--- a/gtav_console/Commands/CommandParser.cs
+++ b/gtav_console/Commands/CommandParser.cs
@@ -6,7 +6,7 @@ using Microsoft.CSharp;
 namespace DeveloperConsole {
     internal class CommandParser {
         private const char EOF = (char) 0;
-        private readonly DeveloperConsole _console;
+        private readonly IDeveloperConsole _console;
         private readonly string _data;
         private int _column;
         private int _line;
@@ -15,7 +15,7 @@ namespace DeveloperConsole {
         private int _saveLine;
         private int _savePos;
 
-        public CommandParser(string data, DeveloperConsole console) {
+        public CommandParser(string data, IDeveloperConsole console) {
             if (data == null) throw new ArgumentNullException("data");
             _data = data;
             _console = console;
@@ -278,10 +278,10 @@ namespace DeveloperConsole {
     }
 
     public class CommandToken {
-        private readonly DeveloperConsole _console;
+        private readonly IDeveloperConsole _console;
 
         public CommandToken(CommandTokenKind kind, string @string, int line, int column,
-            DeveloperConsole console) {
+            IDeveloperConsole console) {
             Kind = kind;
             String = @string;
             Line = line;

--- a/gtav_console/Console/DeveloperConsole.cs
+++ b/gtav_console/Console/DeveloperConsole.cs
@@ -27,7 +27,7 @@ namespace DeveloperConsole {
     /// <summary>
     ///     The console model
     /// </summary>
-    public class DeveloperConsole : Script {
+    public class DeveloperConsole : Script, IDeveloperConsole {
         public delegate void OnConsoleAttached(DeveloperConsole developerConsole);
 
         private const int VkCapital = 0x14;

--- a/gtav_console/Console/IDeveloperConsole.cs
+++ b/gtav_console/Console/IDeveloperConsole.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DeveloperConsole {
+	public interface IDeveloperConsole {
+		void PrintError(string s);
+	}
+}

--- a/gtav_console/DeveloperConsole.csproj
+++ b/gtav_console/DeveloperConsole.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Console\ConsoleSettings.cs" />
     <Compile Include="Commands\DefaultCommands.cs" />
     <Compile Include="Console\DeveloperConsole.cs" />
+    <Compile Include="Console\IDeveloperConsole.cs" />
     <Compile Include="Utils\GTAFuncs.cs" />
     <Compile Include="Console\ObjectSelector.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
I've updated the CommandParser to handle taking negative numbers (primarily for the use in tp command). Rather than it considering the preceding "-" as a word.

Added an interface for DeveloperConsole and added some unit tests to confirm the behavior I changed.
